### PR TITLE
Use custom types in data structures and constants

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -208,16 +208,16 @@ Code snippets appearing in `this style` are to be interpreted as Python code.
 
 ### Initial values
 
-| Name | Value |
-| - | - |
-| `GENESIS_FORK_VERSION` | `0` |
-| `GENESIS_SLOT` | `2**32` |
-| `GENESIS_EPOCH` | `slot_to_epoch(GENESIS_SLOT)` |
-| `GENESIS_START_SHARD` | `0` |
-| `FAR_FUTURE_EPOCH` | `2**64 - 1` |
-| `ZERO_HASH` | `int_to_bytes32(0)` |
-| `EMPTY_SIGNATURE` | `int_to_bytes96(0)` |
-| `BLS_WITHDRAWAL_PREFIX_BYTE` | `int_to_bytes1(0)` |
+| Name | Value | Unit | 
+| - | - | - |
+| `GENESIS_FORK_VERSION` | `0` | uint64 | 
+| `GENESIS_SLOT` | `2**32` | Slot | 
+| `GENESIS_EPOCH` | `slot_to_epoch(GENESIS_SLOT)` | Epoch | 
+| `GENESIS_START_SHARD` | `0` | Shard | 
+| `FAR_FUTURE_EPOCH` | `2**64 - 1` | Epoch | 
+| `ZERO_HASH` | `int_to_bytes32(0)` | Hash |
+| `EMPTY_SIGNATURE` | `int_to_bytes96(0)` | BLSSignature | 
+| `BLS_WITHDRAWAL_PREFIX_BYTE` | `int_to_bytes1(0)` | bytes1 | 
 
 * `GENESIS_SLOT` should be at least as large in terms of time as the largest of the time parameters or state list lengths below (ie. it should be at least as large as any value measured in slots, and at least `SLOTS_PER_EPOCH` times as large as any value measured in epochs).
 
@@ -226,21 +226,21 @@ Code snippets appearing in `this style` are to be interpreted as Python code.
 | Name | Value | Unit | Duration |
 | - | - | :-: | :-: |
 | `SECONDS_PER_SLOT` | `6` | seconds | 6 seconds |
-| `MIN_ATTESTATION_INCLUSION_DELAY` | `2**2` (= 4) | slots | 24 seconds |
-| `SLOTS_PER_EPOCH` | `2**6` (= 64) | slots | 6.4 minutes |
-| `MIN_SEED_LOOKAHEAD` | `2**0` (= 1) | epochs | 6.4 minutes |
-| `ACTIVATION_EXIT_DELAY` | `2**2` (= 4) | epochs | 25.6 minutes |
-| `EPOCHS_PER_ETH1_VOTING_PERIOD` | `2**4` (= 16) | epochs | ~1.7 hours |
-| `MIN_VALIDATOR_WITHDRAWABILITY_DELAY` | `2**8` (= 256) | epochs | ~27 hours |
+| `MIN_ATTESTATION_INCLUSION_DELAY` | `2**2` (= 4) | Slot | 24 seconds |
+| `SLOTS_PER_EPOCH` | `2**6` (= 64) | Slot | 6.4 minutes |
+| `MIN_SEED_LOOKAHEAD` | `2**0` (= 1) | Epoch | 6.4 minutes |
+| `ACTIVATION_EXIT_DELAY` | `2**2` (= 4) | Epoch | 25.6 minutes |
+| `EPOCHS_PER_ETH1_VOTING_PERIOD` | `2**4` (= 16) | Epoch | ~1.7 hours |
+| `MIN_VALIDATOR_WITHDRAWABILITY_DELAY` | `2**8` (= 256) | Epoch | ~27 hours |
 
 ### State list lengths
 
 | Name | Value | Unit | Duration |
 | - | - | :-: | :-: |
-| `LATEST_BLOCK_ROOTS_LENGTH` | `2**13` (= 8,192) | slots | ~13 hours |
-| `LATEST_RANDAO_MIXES_LENGTH` | `2**13` (= 8,192) | epochs | ~36 days |
-| `LATEST_ACTIVE_INDEX_ROOTS_LENGTH` | `2**13` (= 8,192) | epochs | ~36 days |
-| `LATEST_SLASHED_EXIT_LENGTH` | `2**13` (= 8,192) | epochs | ~36 days |
+| `LATEST_BLOCK_ROOTS_LENGTH` | `2**13` (= 8,192) | Slot | ~13 hours |
+| `LATEST_RANDAO_MIXES_LENGTH` | `2**13` (= 8,192) | Epoch | ~36 days |
+| `LATEST_ACTIVE_INDEX_ROOTS_LENGTH` | `2**13` (= 8,192) | Epoch | ~36 days |
+| `LATEST_SLASHED_EXIT_LENGTH` | `2**13` (= 8,192) | Epoch | ~36 days |
 
 ### Reward and penalty quotients
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -270,7 +270,7 @@ Code snippets appearing in `this style` are to be interpreted as Python code.
 ### Signature domains
 
 | Name | Value |
-| --- | --- |
+| - | - |
 | `DOMAIN_DEPOSIT` | `0` |
 | `DOMAIN_ATTESTATION` | `1` |
 | `DOMAIN_PROPOSAL` | `2` |

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -290,6 +290,7 @@ We define the following Python custom types for type hinting and readability:
 | `ValidatorIndex` | `uint64` | a validator registry index |
 | `Gwei` | `uint64` | an amount in Gwei |
 | `Hash` | `bytes32` | result of hashing and its derivatives | 
+| `Bitfield` | `bytes` | an arbitrary length bits sequence | 
 | `BLSPubkey` | `bytes48` | a BLS12-381 public key |
 | `BLSSignature` | `bytes96` | a BLS12-381 signature |
 
@@ -336,7 +337,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     # Attestation data
     'data': AttestationData,
     # Custody bitfield
-    'custody_bitfield': 'bytes',
+    'custody_bitfield': Bitfield,
     # Aggregate signature
     'aggregate_signature': BLSSignature,
 }
@@ -349,11 +350,11 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Attester aggregation bitfield
-    'aggregation_bitfield': 'bytes',
+    'aggregation_bitfield': Bitfield,
     # Attestation data
     'data': AttestationData,
     # Custody bitfield
-    'custody_bitfield': 'bytes',
+    'custody_bitfield': Bitfield,
     # BLS aggregate signature
     'aggregate_signature': BLSSignature,
 }
@@ -603,11 +604,11 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Attester aggregation bitfield
-    'aggregation_bitfield': 'bytes',
+    'aggregation_bitfield': Bitfield,
     # Attestation data
     'data': AttestationData,
     # Custody bitfield
-    'custody_bitfield': 'bytes',
+    'custody_bitfield': Bitfield,
     # Inclusion slot
     'inclusion_slot': Slot,
 }
@@ -994,7 +995,7 @@ def merkle_root(values: List[Hash]) -> Hash:
 ```python
 def get_attestation_participants(state: BeaconState,
                                  attestation_data: AttestationData,
-                                 bitfield: bytes) -> List[ValidatorIndex]:
+                                 bitfield: Bitfield) -> List[ValidatorIndex]:
     """
     Return the participant indices at for the ``attestation_data`` and ``bitfield``.
     """
@@ -1086,7 +1087,7 @@ def get_domain(fork: Fork,
 ### `get_bitfield_bit`
 
 ```python
-def get_bitfield_bit(bitfield: bytes, i: int) -> int:
+def get_bitfield_bit(bitfield: Bitfield, i: int) -> int:
     """
     Extract the bit in ``bitfield`` at position ``i``.
     """
@@ -1096,7 +1097,7 @@ def get_bitfield_bit(bitfield: bytes, i: int) -> int:
 ### `verify_bitfield`
 
 ```python
-def verify_bitfield(bitfield: bytes, committee_size: int) -> bool:
+def verify_bitfield(bitfield: Bitfield, committee_size: int) -> bool:
     """
     Verify ``bitfield`` against the ``committee_size``.
     """

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -289,6 +289,7 @@ We define the following Python custom types for type hinting and readability:
 | `Shard` | `uint64` | a shard number |
 | `ValidatorIndex` | `uint64` | a validator registry index |
 | `Gwei` | `uint64` | an amount in Gwei |
+| `Bytes32` | `bytes32` | 32 bytes of binary data |
 | `Hash` | `bytes32` | result of hashing and its derivatives | 
 | `Bitfield` | `bytes` | an arbitrary length bits sequence | 
 | `BLSPubkey` | `bytes48` | a BLS12-381 public key |
@@ -429,7 +430,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     # BLS pubkey
     'pubkey': BLSPubkey,
     # Withdrawal credentials
-    'withdrawal_credentials': Hash,
+    'withdrawal_credentials': Bytes32,
     # A BLS signature of this `DepositInput`
     'proof_of_possession': BLSSignature,
 }

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -20,6 +20,7 @@
         - [Reward and penalty quotients](#reward-and-penalty-quotients)
         - [Max transactions per block](#max-transactions-per-block)
         - [Signature domains](#signature-domains)
+    - [Custom Types](#custom-types)
     - [Data structures](#data-structures)
         - [Beacon chain transactions](#beacon-chain-transactions)
             - [Proposer slashings](#proposer-slashings)
@@ -51,7 +52,6 @@
             - [`Fork`](#fork)
             - [`Eth1Data`](#eth1data)
             - [`Eth1DataVote`](#eth1datavote)
-    - [Custom Types](#custom-types)
     - [Helper functions](#helper-functions)
         - [`hash`](#hash)
         - [`hash_tree_root`](#hash_tree_root)
@@ -277,6 +277,21 @@ Code snippets appearing in `this style` are to be interpreted as Python code.
 | `DOMAIN_EXIT` | `3` |
 | `DOMAIN_RANDAO` | `4` |
 | `DOMAIN_TRANSFER` | `5` |
+
+## Custom Types
+
+We define the following Python custom types for type hinting and readability:
+
+| Name | SSZ equivalent | Description |
+| - | - | - |
+| `Slot` | `uint64` | a slot number |
+| `Epoch` | `uint64` | an epoch number |
+| `Shard` | `uint64` | a shard number |
+| `ValidatorIndex` | `uint64` | a validator registry index |
+| `Gwei` | `uint64` | an amount in Gwei |
+| `Hash` | `bytes32` | result of hashing and its derivatives | 
+| `BLSPubkey` | `bytes48` | a BLS12-381 public key |
+| `BLSSignature` | `bytes96` | a BLS12-381 signature |
 
 ## Data structures
 
@@ -632,21 +647,6 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     'vote_count': 'uint64',
 }
 ```
-
-## Custom Types
-
-We define the following Python custom types for type hinting and readability:
-
-| Name | SSZ equivalent | Description |
-| - | - | - |
-| `Slot` | `uint64` | a slot number |
-| `Epoch` | `uint64` | an epoch number |
-| `Shard` | `uint64` | a shard number |
-| `ValidatorIndex` | `uint64` | a validator registry index |
-| `Gwei` | `uint64` | an amount in Gwei |
-| `Hash` | `bytes32` | result of hashing and its derivatives | 
-| `BLSPubkey` | `bytes48` | a BLS12-381 public key |
-| `BLSSignature` | `bytes96` | a BLS12-381 signature |
 
 ## Helper functions
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -353,17 +353,17 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     # Shard number
     'shard': Shard,
     # Root of the signed beacon block
-    'beacon_block_root': Bytes32,
+    'beacon_block_root': Hash,
     # Root of the ancestor at the epoch boundary
-    'epoch_boundary_root': Bytes32,
+    'epoch_boundary_root': Hash,
     # Data from the shard since the last attestation
-    'crosslink_data_root': Bytes32,
+    'crosslink_data_root': Hash,
     # Last crosslink
     'latest_crosslink': Crosslink,
     # Last justified epoch in the beacon state
     'justified_epoch': Epoch,
     # Hash of the last justified beacon block
-    'justified_block_root': Bytes32,
+    'justified_block_root': Hash,
 }
 ```
 
@@ -385,7 +385,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Branch in the deposit tree
-    'branch': [Bytes32],
+    'branch': [Hash],
     # Index in the deposit tree
     'index': 'uint64',
     # Data
@@ -413,7 +413,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     # BLS pubkey
     'pubkey': BLSPubkey,
     # Withdrawal credentials
-    'withdrawal_credentials': Bytes32,
+    'withdrawal_credentials': Hash,
     # A BLS signature of this `DepositInput`
     'proof_of_possession': BLSSignature,
 }
@@ -465,8 +465,8 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 {
     # Header
     'slot': Slot,
-    'parent_root': Bytes32,
-    'state_root': Bytes32,
+    'parent_root': Hash,
+    'state_root': Hash,
     'randao_reveal': BLSSignature,
     'eth1_data': Eth1Data,
 
@@ -499,7 +499,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     # Shard number (`BEACON_CHAIN_SHARD_NUMBER` for beacon chain)
     'shard': Shard,
     # Block root
-    'block_root': Bytes32,
+    'block_root': Hash,
     # Signature
     'signature': BLSSignature,
 }
@@ -522,13 +522,13 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     'validator_registry_update_epoch': Epoch,
 
     # Randomness and committees
-    'latest_randao_mixes': [Bytes32],
+    'latest_randao_mixes': [Hash],
     'previous_shuffling_start_shard': Shard,
     'current_shuffling_start_shard': Shard,
     'previous_shuffling_epoch': Epoch,
     'current_shuffling_epoch': Epoch,
-    'previous_shuffling_seed': Bytes32,
-    'current_shuffling_seed': Bytes32,
+    'previous_shuffling_seed': Hash,
+    'current_shuffling_seed': Hash,
 
     # Finality
     'previous_justified_epoch': Epoch,
@@ -538,11 +538,11 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 
     # Recent state
     'latest_crosslinks': [Crosslink],
-    'latest_block_roots': [Bytes32],
-    'latest_active_index_roots': [Bytes32],
+    'latest_block_roots': [Hash],
+    'latest_active_index_roots': [Hash],
     'latest_slashed_balances': [Gwei],  # Balances slashed at every withdrawal period
     'latest_attestations': [PendingAttestation],
-    'batched_block_roots': [Bytes32],
+    'batched_block_roots': [Hash],
 
     # Ethereum 1.0 chain data
     'latest_eth1_data': Eth1Data,
@@ -558,7 +558,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     # BLS public key
     'pubkey': BLSPubkey,
     # Withdrawal credentials
-    'withdrawal_credentials': Bytes32,
+    'withdrawal_credentials': Hash,
     # Epoch when validator activated
     'activation_epoch': Epoch,
     # Epoch when validator exited
@@ -579,7 +579,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     # Epoch number
     'epoch': Epoch,
     # Shard data since the previous crosslink
-    'crosslink_data_root': Bytes32,
+    'crosslink_data_root': Hash,
 }
 ```
 
@@ -616,9 +616,9 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Root of the deposit tree
-    'deposit_root': Bytes32,
+    'deposit_root': Hash,
     # Block hash
-    'block_hash': Bytes32,
+    'block_hash': Hash,
 }
 ```
 
@@ -644,7 +644,7 @@ We define the following Python custom types for type hinting and readability:
 | `Shard` | `uint64` | a shard number |
 | `ValidatorIndex` | `uint64` | a validator registry index |
 | `Gwei` | `uint64` | an amount in Gwei |
-| `Bytes32` | `bytes32` | 32 bytes of binary data |
+| `Hash` | `bytes32` | result of hashing and its derivatives | 
 | `BLSPubkey` | `bytes48` | a BLS12-381 public key |
 | `BLSSignature` | `bytes96` | a BLS12-381 signature |
 
@@ -660,11 +660,11 @@ Note: We aim to migrate to a S[T/N]ARK-friendly hash function in a future Ethere
 
 ### `hash_tree_root`
 
-`def hash_tree_root(object: SSZSerializable) -> Bytes32` is a function for hashing objects into a single root utilizing a hash tree structure. `hash_tree_root` is defined in the [SimpleSerialize spec](https://github.com/ethereum/eth2.0-specs/blob/master/specs/simple-serialize.md#tree-hash).
+`def hash_tree_root(object: SSZSerializable) -> Hash` is a function for hashing objects into a single root utilizing a hash tree structure. `hash_tree_root` is defined in the [SimpleSerialize spec](https://github.com/ethereum/eth2.0-specs/blob/master/specs/simple-serialize.md#tree-hash).
 
 ### `signed_root`
 
-`def signed_root(object: SSZContainer) -> Bytes32` is a function defined in the [SimpleSerialize spec](https://github.com/ethereum/eth2.0-specs/blob/master/specs/simple-serialize.md#signed-roots) to compute signed messages.
+`def signed_root(object: SSZContainer) -> Hash` is a function defined in the [SimpleSerialize spec](https://github.com/ethereum/eth2.0-specs/blob/master/specs/simple-serialize.md#signed-roots) to compute signed messages.
 
 ### `slot_to_epoch`
 
@@ -728,7 +728,7 @@ def get_active_validator_indices(validators: List[Validator], epoch: Epoch) -> L
 ### `get_permuted_index`
 
 ```python
-def get_permuted_index(index: int, list_size: int, seed: Bytes32) -> int:
+def get_permuted_index(index: int, list_size: int, seed: Hash) -> int:
     """
     Return `p(index)` in a pseudorandom permutation `p` of `0...list_size-1` with ``seed`` as entropy.
 
@@ -784,7 +784,7 @@ def get_epoch_committee_count(active_validator_count: int) -> int:
 ### `get_shuffling`
 
 ```python
-def get_shuffling(seed: Bytes32,
+def get_shuffling(seed: Hash,
                   validators: List[Validator],
                   epoch: Epoch) -> List[List[ValidatorIndex]]
     """
@@ -913,7 +913,7 @@ def get_crosslink_committees_at_slot(state: BeaconState,
 
 ```python
 def get_block_root(state: BeaconState,
-                   slot: Slot) -> Bytes32:
+                   slot: Slot) -> Hash:
     """
     Return the block root at a recent ``slot``.
     """
@@ -928,7 +928,7 @@ def get_block_root(state: BeaconState,
 
 ```python
 def get_randao_mix(state: BeaconState,
-                   epoch: Epoch) -> Bytes32:
+                   epoch: Epoch) -> Hash:
     """
     Return the randao mix at a recent ``epoch``.
     """
@@ -940,7 +940,7 @@ def get_randao_mix(state: BeaconState,
 
 ```python
 def get_active_index_root(state: BeaconState,
-                          epoch: Epoch) -> Bytes32:
+                          epoch: Epoch) -> Hash:
     """
     Return the index root at a recent ``epoch``.
     """
@@ -952,7 +952,7 @@ def get_active_index_root(state: BeaconState,
 
 ```python
 def generate_seed(state: BeaconState,
-                  epoch: Epoch) -> Bytes32:
+                  epoch: Epoch) -> Hash:
     """
     Generate a seed for the given ``epoch``.
     """
@@ -978,7 +978,7 @@ def get_beacon_proposer_index(state: BeaconState,
 ### `merkle_root`
 
 ```python
-def merkle_root(values: List[Bytes32]) -> Bytes32:
+def merkle_root(values: List[Hash]) -> Hash:
     """
     Merkleize ``values`` (where ``len(values)`` is a power of two) and return the Merkle root.
     Note that the leaves are not hashed.
@@ -1714,7 +1714,7 @@ For each `deposit` in `block.body.deposits`:
 * Verify that `verify_merkle_branch(hash(serialized_deposit_data), deposit.branch, DEPOSIT_CONTRACT_TREE_DEPTH, deposit.index, state.latest_eth1_data.deposit_root)` is `True`.
 
 ```python
-def verify_merkle_branch(leaf: Bytes32, branch: List[Bytes32], depth: int, index: int, root: Bytes32) -> bool:
+def verify_merkle_branch(leaf: Hash, branch: List[Hash], depth: int, index: int, root: Hash) -> bool:
     """
     Verify that the given ``leaf`` is on the merkle branch ``branch``.
     """

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -270,7 +270,7 @@ Code snippets appearing in `this style` are to be interpreted as Python code.
 ### Signature domains
 
 | Name | Value |
-| - | - |
+| --- | --- |
 | `DOMAIN_DEPOSIT` | `0` |
 | `DOMAIN_ATTESTATION` | `1` |
 | `DOMAIN_PROPOSAL` | `2` |
@@ -291,7 +291,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Proposer index
-    'proposer_index': 'uint64',
+    'proposer_index': ValidatorIndex,
     # First proposal
     'proposal_1': Proposal,
     # Second proposal
@@ -317,13 +317,13 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Validator indices
-    'validator_indices': ['uint64'],
+    'validator_indices': [ValidatorIndex],
     # Attestation data
     'data': AttestationData,
     # Custody bitfield
     'custody_bitfield': 'bytes',
     # Aggregate signature
-    'aggregate_signature': 'bytes96',
+    'aggregate_signature': BLSSignature,
 }
 ```
 
@@ -340,7 +340,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     # Custody bitfield
     'custody_bitfield': 'bytes',
     # BLS aggregate signature
-    'aggregate_signature': 'bytes96',
+    'aggregate_signature': BLSSignature,
 }
 ```
 
@@ -349,21 +349,21 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Slot number
-    'slot': 'uint64',
+    'slot': Slot,
     # Shard number
-    'shard': 'uint64',
+    'shard': Shard,
     # Root of the signed beacon block
-    'beacon_block_root': 'bytes32',
+    'beacon_block_root': Bytes32,
     # Root of the ancestor at the epoch boundary
-    'epoch_boundary_root': 'bytes32',
+    'epoch_boundary_root': Bytes32,
     # Data from the shard since the last attestation
-    'crosslink_data_root': 'bytes32',
+    'crosslink_data_root': Bytes32,
     # Last crosslink
     'latest_crosslink': Crosslink,
     # Last justified epoch in the beacon state
-    'justified_epoch': 'uint64',
+    'justified_epoch': Epoch,
     # Hash of the last justified beacon block
-    'justified_block_root': 'bytes32',
+    'justified_block_root': Bytes32,
 }
 ```
 
@@ -385,7 +385,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Branch in the deposit tree
-    'branch': ['bytes32'],
+    'branch': [Bytes32],
     # Index in the deposit tree
     'index': 'uint64',
     # Data
@@ -398,7 +398,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Amount in Gwei
-    'amount': 'uint64',
+    'amount': Gwei,
     # Timestamp from deposit contract
     'timestamp': 'uint64',
     # Deposit input
@@ -411,11 +411,11 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # BLS pubkey
-    'pubkey': 'bytes48',
+    'pubkey': BLSPubkey,
     # Withdrawal credentials
-    'withdrawal_credentials': 'bytes32',
+    'withdrawal_credentials': Bytes32,
     # A BLS signature of this `DepositInput`
-    'proof_of_possession': 'bytes96',
+    'proof_of_possession': BLSSignature,
 }
 ```
 
@@ -426,11 +426,11 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Minimum epoch for processing exit
-    'epoch': 'uint64',
+    'epoch': Epoch,
     # Index of the exiting validator
-    'validator_index': 'uint64',
+    'validator_index': ValidatorIndex,
     # Validator signature
-    'signature': 'bytes96',
+    'signature': BLSSignature,
 }
 ```
 
@@ -441,19 +441,19 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Sender index
-    'from': 'uint64',
+    'from': ValidatorIndex,
     # Recipient index
-    'to': 'uint64',
+    'to': ValidatorIndex,
     # Amount in Gwei
-    'amount': 'uint64',
+    'amount': Gwei,
     # Fee in Gwei for block proposer
-    'fee': 'uint64',
+    'fee': Gwei,
     # Inclusion slot
-    'slot': 'uint64',
+    'slot': Slot,
     # Sender withdrawal pubkey
-    'pubkey': 'bytes48',
+    'pubkey': BLSPubkey,
     # Sender signature
-    'signature': 'bytes96',
+    'signature': BLSSignature,
 }
 ```
 
@@ -464,16 +464,16 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Header
-    'slot': 'uint64',
-    'parent_root': 'bytes32',
-    'state_root': 'bytes32',
-    'randao_reveal': 'bytes96',
+    'slot': Slot,
+    'parent_root': Bytes32,
+    'state_root': Bytes32,
+    'randao_reveal': BLSSignature,
     'eth1_data': Eth1Data,
 
     # Body
     'body': BeaconBlockBody,
     # Signature
-    'signature': 'bytes96',
+    'signature': BLSSignature,
 }
 ```
 
@@ -495,13 +495,13 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Slot number
-    'slot': 'uint64',
+    'slot': Slot,
     # Shard number (`BEACON_CHAIN_SHARD_NUMBER` for beacon chain)
-    'shard': 'uint64',
+    'shard': Shard,
     # Block root
-    'block_root': 'bytes32',
+    'block_root': Bytes32,
     # Signature
-    'signature': 'bytes96',
+    'signature': BLSSignature,
 }
 ```
 
@@ -512,42 +512,42 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Misc
-    'slot': 'uint64',
+    'slot': Slot,
     'genesis_time': 'uint64',
     'fork': Fork,  # For versioning hard forks
 
     # Validator registry
     'validator_registry': [Validator],
-    'validator_balances': ['uint64'],
-    'validator_registry_update_epoch': 'uint64',
+    'validator_balances': [Gwei],
+    'validator_registry_update_epoch': Epoch,
 
     # Randomness and committees
-    'latest_randao_mixes': ['bytes32'],
-    'previous_shuffling_start_shard': 'uint64',
-    'current_shuffling_start_shard': 'uint64',
-    'previous_shuffling_epoch': 'uint64',
-    'current_shuffling_epoch': 'uint64',
-    'previous_shuffling_seed': 'bytes32',
-    'current_shuffling_seed': 'bytes32',
+    'latest_randao_mixes': [Bytes32],
+    'previous_shuffling_start_shard': Shard,
+    'current_shuffling_start_shard': Shard,
+    'previous_shuffling_epoch': Epoch,
+    'current_shuffling_epoch': Epoch,
+    'previous_shuffling_seed': Bytes32,
+    'current_shuffling_seed': Bytes32,
 
     # Finality
-    'previous_justified_epoch': 'uint64',
-    'justified_epoch': 'uint64',
+    'previous_justified_epoch': Epoch,
+    'justified_epoch': Epoch,
     'justification_bitfield': 'uint64',
-    'finalized_epoch': 'uint64',
+    'finalized_epoch': Epoch,
 
     # Recent state
     'latest_crosslinks': [Crosslink],
-    'latest_block_roots': ['bytes32'],
-    'latest_active_index_roots': ['bytes32'],
-    'latest_slashed_balances': ['uint64'],  # Balances slashed at every withdrawal period
+    'latest_block_roots': [Bytes32],
+    'latest_active_index_roots': [Bytes32],
+    'latest_slashed_balances': [Gwei],  # Balances slashed at every withdrawal period
     'latest_attestations': [PendingAttestation],
-    'batched_block_roots': ['bytes32'],
+    'batched_block_roots': [Bytes32],
 
     # Ethereum 1.0 chain data
     'latest_eth1_data': Eth1Data,
     'eth1_data_votes': [Eth1DataVote],
-    'deposit_index': 'uint64'
+    'deposit_index': ValidatorIndex
 }
 ```
 
@@ -556,15 +556,15 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # BLS public key
-    'pubkey': 'bytes48',
+    'pubkey': BLSPubkey,
     # Withdrawal credentials
-    'withdrawal_credentials': 'bytes32',
+    'withdrawal_credentials': Bytes32,
     # Epoch when validator activated
-    'activation_epoch': 'uint64',
+    'activation_epoch': Epoch,
     # Epoch when validator exited
-    'exit_epoch': 'uint64',
+    'exit_epoch': Epoch,
     # Epoch when validator is eligible to withdraw
-    'withdrawable_epoch': 'uint64',
+    'withdrawable_epoch': Epoch,
     # Did the validator initiate an exit
     'initiated_exit': 'bool',
     # Was the validator slashed
@@ -577,9 +577,9 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Epoch number
-    'epoch': 'uint64',
+    'epoch': Epoch,
     # Shard data since the previous crosslink
-    'crosslink_data_root': 'bytes32',
+    'crosslink_data_root': Bytes32,
 }
 ```
 
@@ -594,7 +594,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     # Custody bitfield
     'custody_bitfield': 'bytes',
     # Inclusion slot
-    'inclusion_slot': 'uint64',
+    'inclusion_slot': Slot,
 }
 ```
 
@@ -607,7 +607,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     # Current fork version
     'current_version': 'uint64',
     # Fork epoch number
-    'epoch': 'uint64',
+    'epoch': Epoch,
 }
 ```
 
@@ -616,9 +616,9 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     # Root of the deposit tree
-    'deposit_root': 'bytes32',
+    'deposit_root': Bytes32,
     # Block hash
-    'block_hash': 'bytes32',
+    'block_hash': Bytes32,
 }
 ```
 


### PR DESCRIPTION
Original issue: https://github.com/ethereum/eth2.0-specs/issues/667

The goal is to improve Spec readability by using alias custom types in data structures and as constant units instead of generic types.

## What was done 
- Add `Hash` and `Bitfield` custom types. The `Hash` type is treated as a result of any 256-bit cryptographic hash function or its derivative preserving hash properties (like `xor`ing two hashes)
- Replace generic SSZ types in data structures with custom types where appropriate
- Add/update constant units according to custom types 

## What else can be done
- Add more custom types (like `Time`, `ForkVersion`, `Bitfield64`) which are now referred at 1-2 places in the Spec
- As per @hwwhww suggestion in https://github.com/ethereum/eth2.0-specs/issues/667 cover *all* elements with custom types 
- In some way describe array index types (like  `'validator_balances': [ValidatorIndex => Gwei]`)